### PR TITLE
Add APA_ACCESS_TOKEN support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,15 @@ FROM python:3.11-slim
 # Set working directory in container
 WORKDIR /app
 
-# Set build arguments for tokens
+# Set build argument for refresh token
 ARG APA_REFRESH_TOKEN
-ARG APA_ACCESS_TOKEN
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     FLASK_APP=src/app.py \
     FLASK_ENV=production \
-    APA_REFRESH_TOKEN=${APA_REFRESH_TOKEN} \
-    APA_ACCESS_TOKEN=${APA_ACCESS_TOKEN}
+    APA_REFRESH_TOKEN=${APA_REFRESH_TOKEN}
 
 # Install system dependencies
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ FROM python:3.11-slim
 # Set working directory in container
 WORKDIR /app
 
+# Set build argument and environment variable for refresh token
+ARG APA_REFRESH_TOKEN
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     FLASK_APP=src/app.py \
-    FLASK_ENV=production
+    FLASK_ENV=production \
+    APA_REFRESH_TOKEN=${APA_REFRESH_TOKEN}
 
 # Install system dependencies
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,17 @@ FROM python:3.11-slim
 # Set working directory in container
 WORKDIR /app
 
-# Set build argument and environment variable for refresh token
+# Set build arguments for tokens
 ARG APA_REFRESH_TOKEN
+ARG APA_ACCESS_TOKEN
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     FLASK_APP=src/app.py \
     FLASK_ENV=production \
-    APA_REFRESH_TOKEN=${APA_REFRESH_TOKEN}
+    APA_REFRESH_TOKEN=${APA_REFRESH_TOKEN} \
+    APA_ACCESS_TOKEN=${APA_ACCESS_TOKEN}
 
 # Install system dependencies
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ python -m flask run
 
 # Or with Docker
 docker build -t apalens .
-docker run -p 5000:5000 apalens
+docker run -p 5000:5000 \
+  -e APA_REFRESH_TOKEN=your-apa-refresh-token \
+  apalens
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ A Flask web application for viewing APA (American Poolplayers Association) team 
 # Install and run
 pip install -e .
 export APA_REFRESH_TOKEN="your-apa-refresh-token"
-export APA_ACCESS_TOKEN="your-apa-access-token"
 python -m flask run
 
 # Or with Docker
 docker build -t apalens .
-docker run -p 5000:5000 \
-  -e APA_REFRESH_TOKEN=your-apa-refresh-token \
-  -e APA_ACCESS_TOKEN=your-apa-access-token \
-  apalens
+docker run -p 5000:5000 -e APA_REFRESH_TOKEN=your-apa-refresh-token apalens
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ A Flask web application for viewing APA (American Poolplayers Association) team 
 # Install and run
 pip install -e .
 export APA_REFRESH_TOKEN="your-apa-refresh-token"
+export APA_ACCESS_TOKEN="your-apa-access-token"
 python -m flask run
 
 # Or with Docker
 docker build -t apalens .
 docker run -p 5000:5000 \
   -e APA_REFRESH_TOKEN=your-apa-refresh-token \
+  -e APA_ACCESS_TOKEN=your-apa-access-token \
   apalens
 ```
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,8 @@
+import os
 from flask import Flask, render_template
 
 app = Flask(__name__)
+app.config["APA_REFRESH_TOKEN"] = os.getenv("APA_REFRESH_TOKEN")
 
 
 @app.route("/")

--- a/src/app.py
+++ b/src/app.py
@@ -1,8 +1,10 @@
 import os
+
 from flask import Flask, render_template
 
 app = Flask(__name__)
 app.config["APA_REFRESH_TOKEN"] = os.getenv("APA_REFRESH_TOKEN")
+app.config["APA_ACCESS_TOKEN"] = os.getenv("APA_ACCESS_TOKEN")
 
 
 @app.route("/")

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,6 @@ from flask import Flask, render_template
 
 app = Flask(__name__)
 app.config["APA_REFRESH_TOKEN"] = os.getenv("APA_REFRESH_TOKEN")
-app.config["APA_ACCESS_TOKEN"] = os.getenv("APA_ACCESS_TOKEN")
 
 
 @app.route("/")


### PR DESCRIPTION
## Summary
- configure APA refresh token in Docker build
- load refresh token in the Flask app
- show refresh token usage in README

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685c96e2f83c832ba1cbdbb237892278